### PR TITLE
Fixed typos and made commands more consistent

### DIFF
--- a/SubBot/Commands/Administrator/Ban.cs
+++ b/SubBot/Commands/Administrator/Ban.cs
@@ -7,7 +7,6 @@ namespace DevSubmarine.SubBot.Commands.Administrator
 {
     public class Ban : ModuleBase<SocketCommandContext>
     {
-        [RequireOwner]
         [RequireContext(ContextType.Guild, ErrorMessage = "Please use this command in a server!")]
         [RequireBotPermission(GuildPermission.BanMembers, ErrorMessage = "I do not have the permission to `Ban Members`")]
         [RequireBotPermission(GuildPermission.BanMembers, ErrorMessage = "You do not have the permission to `Ban Members`")]

--- a/SubBot/Commands/Administrator/Ban.cs
+++ b/SubBot/Commands/Administrator/Ban.cs
@@ -16,7 +16,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
         {
             if (user == null)
             {
-                var nullUser = new EmbedBuilder()
+                Embed nullUser = new EmbedBuilder()
                     .WithColor(Color.Red)
                     .WithTitle("Ban Command : Info")
                     .AddField("Usage:", "`ban <user> <reason*> <pruneMessages* (days)>`", true)
@@ -32,7 +32,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 {
                     await user.BanAsync(pruneDays, reason);
 
-                    var successBan = new EmbedBuilder()
+                    Embed successBan = new EmbedBuilder()
                         .WithColor(Color.Green)
                         .WithAuthor("Ban Command : Success", user.GetAvatarUrl())
                         .WithDescription($"Successfully banned {user.Mention}")
@@ -41,7 +41,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 }
                 catch (Exception ex)
                 {
-                    var errorBan = new EmbedBuilder()
+                    Embed errorBan = new EmbedBuilder()
                         .WithColor(Color.Red)
                         .WithTitle("Ban Command : Error")
                         .WithDescription(ex.Message)

--- a/SubBot/Commands/Administrator/Ban.cs
+++ b/SubBot/Commands/Administrator/Ban.cs
@@ -9,7 +9,8 @@ namespace DevSubmarine.SubBot.Commands.Administrator
     {
         [RequireOwner]
         [RequireContext(ContextType.Guild, ErrorMessage = "Please use this command in a server!")]
-        [RequireBotPermission(GuildPermission.BanMembers, ErrorMessage = "I do not have permission: `Ban Members`")]
+        [RequireBotPermission(GuildPermission.BanMembers, ErrorMessage = "I do not have the permission to `Ban Members`")]
+        [RequireBotPermission(GuildPermission.BanMembers, ErrorMessage = "You do not have the permission to `Ban Members`")]
         [Command("ban")]
         public async Task BanUser(IGuildUser user = null, string reason = "Not specified!", [Remainder] int pruneDays = 0)
         {

--- a/SubBot/Commands/Administrator/Ban.cs
+++ b/SubBot/Commands/Administrator/Ban.cs
@@ -15,7 +15,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
         {
             if (user == null)
             {
-                Embed nullUser = new EmbedBuilder()
+                var nullUser = new EmbedBuilder()
                     .WithColor(Color.Red)
                     .WithTitle("Ban Command : Info")
                     .AddField("Usage:", "`ban <user> <reason*> <pruneMessages* (days)>`", true)
@@ -31,7 +31,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 {
                     await user.BanAsync(pruneDays, reason);
 
-                    Embed successBan = new EmbedBuilder()
+                    var successBan = new EmbedBuilder()
                         .WithColor(Color.Green)
                         .WithAuthor("Ban Command : Success", user.GetAvatarUrl())
                         .WithDescription($"Successfully banned {user.Mention}")
@@ -40,7 +40,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 }
                 catch (Exception ex)
                 {
-                    Embed errorBan = new EmbedBuilder()
+                    var errorBan = new EmbedBuilder()
                         .WithColor(Color.Red)
                         .WithTitle("Ban Command : Error")
                         .WithDescription(ex.Message)

--- a/SubBot/Commands/Administrator/Kick.cs
+++ b/SubBot/Commands/Administrator/Kick.cs
@@ -7,7 +7,6 @@ namespace DevSubmarine.SubBot.Commands.Administrator
 {
     public class Kick : ModuleBase<SocketCommandContext>
     {
-        [RequireOwner]
         [RequireContext(ContextType.Guild, ErrorMessage = "Please use this command in a server!")]
         [RequireUserPermission(GuildPermission.KickMembers, ErrorMessage = "You do not have permission to `Kick Members`")]
         [RequireBotPermission(GuildPermission.KickMembers, ErrorMessage = "I do not have permission to `Kick Members`")]

--- a/SubBot/Commands/Administrator/Kick.cs
+++ b/SubBot/Commands/Administrator/Kick.cs
@@ -9,7 +9,8 @@ namespace DevSubmarine.SubBot.Commands.Administrator
     {
         [RequireOwner]
         [RequireContext(ContextType.Guild, ErrorMessage = "Please use this command in a server!")]
-        [RequireUserPermission(GuildPermission.KickMembers, ErrorMessage = "You do not have permission: `Kick Members`")]
+        [RequireUserPermission(GuildPermission.KickMembers, ErrorMessage = "You do not have permission to `Kick Members`")]
+        [RequireBotPermission(GuildPermission.KickMembers, ErrorMessage = "I do not have permission to `Kick Members`")]
         [Command("kick")]
         public async Task KickUser(IGuildUser user = null, string reason = "Not specified!")
         {

--- a/SubBot/Commands/Administrator/Kick.cs
+++ b/SubBot/Commands/Administrator/Kick.cs
@@ -41,7 +41,6 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 catch (Exception ex)
                 {
                     Embed errorKick = new EmbedBuilder()
-
                         .WithColor(Color.Red)
                         .WithTitle("Kick Command : Error")
                         .WithDescription(ex.Message)

--- a/SubBot/Commands/Administrator/Kick.cs
+++ b/SubBot/Commands/Administrator/Kick.cs
@@ -34,7 +34,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                     Embed successKick = new EmbedBuilder()
                         .WithColor(Color.Green)
                         .WithAuthor("Kick Command : Success", user.GetAvatarUrl())
-                        .WithDescription($"Successfully banned {user.Mention}")
+                        .WithDescription($"Successfully kicked {user.Mention}")
                         .Build();
                     await Context.Message.Channel.SendMessageAsync(embed: successKick);
                 }

--- a/SubBot/Commands/Administrator/Purge.cs
+++ b/SubBot/Commands/Administrator/Purge.cs
@@ -11,7 +11,8 @@ namespace DevSubmarine.SubBot.Commands.Administrator
     {
         [Command("purge"), Alias("delete")]
         [RequireContext(ContextType.Guild, ErrorMessage = "Please use this command in a server!")]
-        [RequireUserPermission(GuildPermission.ManageMessages, ErrorMessage = "You do not have permission `Manage Messages`")]
+        [RequireUserPermission(GuildPermission.ManageMessages, ErrorMessage = "You do not have the permission to `Manage Messages`")]
+        [RequireBotPermission(GuildPermission.ManageMessages, ErrorMessage = "I do not have the permission to `Manage Messages`")]
         public async Task PurgeMessages(int? msgToDel = null)
         {
             if (msgToDel == null || msgToDel == 0)

--- a/SubBot/Commands/Administrator/Purge.cs
+++ b/SubBot/Commands/Administrator/Purge.cs
@@ -20,7 +20,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                     .WithColor(Color.Blue)
                     .WithTitle("Purge Messages : Info")
                     .AddField("Info", "Deletes a specified amount of messages")
-                    .AddField("To Use", "`purge/delete {NumOfMessages}`")
+                    .AddField("To Use", "`purge/delete <message count>`")
                     .Build();
                 await Context.Channel.SendMessageAsync(embed: NullEmbed);
             }

--- a/SubBot/Commands/Administrator/Purge.cs
+++ b/SubBot/Commands/Administrator/Purge.cs
@@ -16,13 +16,13 @@ namespace DevSubmarine.SubBot.Commands.Administrator
         {
             if (msgToDel == null || msgToDel == 0)
             {
-                Embed NullEmbed = new EmbedBuilder()
+                Embed nullEmbed = new EmbedBuilder()
                     .WithColor(Color.Blue)
                     .WithTitle("Purge Messages : Info")
                     .AddField("Info", "Deletes a specified amount of messages")
                     .AddField("To Use", "`purge/delete <message count>`")
                     .Build();
-                await Context.Channel.SendMessageAsync(embed: NullEmbed);
+                await Context.Channel.SendMessageAsync(embed: nullEmbed);
             }
 
             else
@@ -48,17 +48,17 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                     {
                         await (Context.Channel as ITextChannel).DeleteMessagesAsync(filteredMessages);
 
-                        Embed Success = new EmbedBuilder()
+                        var success = new EmbedBuilder()
                             .WithColor(Color.Green)
                             .WithTitle("Purge Messages : Success")
                             .WithDescription($"Done. Removed {count} {(count > 1 ? "messages" : "message")}.")
                             .Build();
-                        await Context.Message.Channel.SendMessageAsync(embed: Success);
+                        await Context.Message.Channel.SendMessageAsync(embed: success);
                     }
 
                     catch (Exception ex)
                     {
-                        Embed errorSlowmode = new EmbedBuilder()
+                        var errorSlowmode = new EmbedBuilder()
                         .WithColor(Color.Red)
                         .WithTitle("Purge Messages : Error")
                         .WithDescription(ex.Message)

--- a/SubBot/Commands/Administrator/Purge.cs
+++ b/SubBot/Commands/Administrator/Purge.cs
@@ -31,7 +31,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 int amount = Convert.ToInt32(msgToDel);
                 var messages = await Context.Channel.GetMessagesAsync(Context.Message, Direction.Before, amount).FlattenAsync();
                 var filteredMessages = messages.Where(x => (DateTimeOffset.UtcNow - x.Timestamp).TotalDays <= 14);
-                var count = filteredMessages.Count();
+                int count = filteredMessages.Count();
 
                 if (count < 0 || count > 101)
                 {
@@ -49,7 +49,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                     {
                         await (Context.Channel as ITextChannel).DeleteMessagesAsync(filteredMessages);
 
-                        var success = new EmbedBuilder()
+                        Embed success = new EmbedBuilder()
                             .WithColor(Color.Green)
                             .WithTitle("Purge Messages : Success")
                             .WithDescription($"Done. Removed {count} {(count > 1 ? "messages" : "message")}.")
@@ -59,12 +59,12 @@ namespace DevSubmarine.SubBot.Commands.Administrator
 
                     catch (Exception ex)
                     {
-                        var errorSlowmode = new EmbedBuilder()
-                        .WithColor(Color.Red)
-                        .WithTitle("Purge Messages : Error")
-                        .WithDescription(ex.Message)
-                        .WithFooter($"{ex.HResult}")
-                        .Build();
+                        Embed errorSlowmode = new EmbedBuilder()
+                            .WithColor(Color.Red)
+                            .WithTitle("Purge Messages : Error")
+                            .WithDescription(ex.Message)
+                            .WithFooter($"{ex.HResult}")
+                            .Build();
                         await Context.Message.Channel.SendMessageAsync(embed: errorSlowmode);
                     }
                 }

--- a/SubBot/Commands/Administrator/Slowmode.cs
+++ b/SubBot/Commands/Administrator/Slowmode.cs
@@ -16,7 +16,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
         {
             if (duration == null)
             {
-                var slowmodeInfo = new EmbedBuilder()
+                Embed slowmodeInfo = new EmbedBuilder()
                     .WithColor(Color.Blue)
                     .WithTitle("Slowmode Command : Info")
                     .AddField("Info", "Sets the slowmode of text channels in seconds.")
@@ -29,7 +29,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
 
             else if (duration > 21600) // 21600 = 6 hours
             {
-                var maxLimit = new EmbedBuilder()
+                Embed maxLimit = new EmbedBuilder()
                     .WithColor(Color.Red)
                     .WithTitle("Slowmode Command : Error")
                     .WithDescription("You cannot use more than 21600 (6 hours)!")
@@ -40,7 +40,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
 
             else if (duration < 0)
             {
-                var minLimit = new EmbedBuilder()
+                Embed minLimit = new EmbedBuilder()
                     .WithColor(Color.Red)
                     .WithTitle("Slowmode Command : Error")
                     .WithDescription("You cannot use less than 0!")
@@ -59,7 +59,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
 
                     await channel.ModifyAsync(x => x.SlowModeInterval = Convert.ToInt32(duration));
 
-                    var Result = new EmbedBuilder()
+                    Embed Result = new EmbedBuilder()
                         .WithColor(Color.Green)
                         .WithTitle("Slowmode Command : Success")
                         .WithDescription($"Slowmode of {duration} seconds was set!")

--- a/SubBot/Commands/Administrator/Slowmode.cs
+++ b/SubBot/Commands/Administrator/Slowmode.cs
@@ -70,7 +70,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                 {
                     Embed errorSlowmode = new EmbedBuilder()
                         .WithColor(Color.Red)
-                        .WithTitle("Kick Command : Error")
+                        .WithTitle("Slowmode Command : Error")
                         .WithDescription(ex.Message)
                         .WithFooter($"{ex.HResult}")
                         .Build();

--- a/SubBot/Commands/Administrator/Slowmode.cs
+++ b/SubBot/Commands/Administrator/Slowmode.cs
@@ -15,7 +15,7 @@ namespace DevSubmarine.SubBot.Commands.Administrator
         {
             if (duration == null)
             {
-                var SlowModeInfo = new EmbedBuilder()
+                var slowmodeInfo = new EmbedBuilder()
                     .WithColor(Color.Blue)
                     .WithTitle("Slowmode Command : Info")
                     .AddField("Info", "Sets the slowmode of text channels in seconds.")
@@ -23,29 +23,29 @@ namespace DevSubmarine.SubBot.Commands.Administrator
                     .WithFooter("Note: <duration> is in seconds")
                     .Build();
 
-                await Context.Channel.SendMessageAsync(embed: SlowModeInfo);
+                await Context.Channel.SendMessageAsync(embed: slowmodeInfo);
             }
 
             else if (duration > 21600) // 21600 = 6 hours
             {
-                var MaxLimit = new EmbedBuilder()
+                var maxLimit = new EmbedBuilder()
                     .WithColor(Color.Red)
                     .WithTitle("Slowmode Command : Error")
                     .WithDescription("You cannot use more than 21600 (6 hours)!")
                     .Build();
 
-                await Context.Channel.SendMessageAsync(embed: MaxLimit);
+                await Context.Channel.SendMessageAsync(embed: maxLimit);
             }
 
             else if (duration < 0)
             {
-                var MinLimit = new EmbedBuilder()
+                var minLimit = new EmbedBuilder()
                     .WithColor(Color.Red)
                     .WithTitle("Slowmode Command : Error")
                     .WithDescription("You cannot use less than 0!")
                     .Build();
 
-                await Context.Channel.SendMessageAsync(embed: MinLimit);
+                await Context.Channel.SendMessageAsync(embed: minLimit);
             }
 
             else if (duration != null && duration > -1 && duration < 21601)

--- a/SubBot/Commands/Administrator/Slowmode.cs
+++ b/SubBot/Commands/Administrator/Slowmode.cs
@@ -10,7 +10,8 @@ namespace DevSubmarine.SubBot.Commands.Administrator
     {
         [Command("slowmode"), Alias("sm")]
         [RequireContext(ContextType.Guild, ErrorMessage = "Please use this command in a server!")]
-        [RequireUserPermission(GuildPermission.ManageChannels, ErrorMessage = "You do not have permission `Manage Channels`")]
+        [RequireUserPermission(GuildPermission.ManageChannels, ErrorMessage = "I do not have the permission to `Manage Channels`")]
+        [RequireBotPermission(GuildPermission.ManageChannels, ErrorMessage = "You do not have the permission to `Manage Channels`")]
         public async Task SetSlowmode(int? duration = null)
         {
             if (duration == null)


### PR DESCRIPTION
In a nutshell, the typos, variable names and attributes were improved from the commands folder.

And also I removed an attribute from the ban command as I forgot to remove it previously.